### PR TITLE
Use $0 instead of $_ for sysroot inference

### DIFF
--- a/sysroot/run.sh
+++ b/sysroot/run.sh
@@ -1,6 +1,6 @@
 #!/system/bin/env sh
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-SYSROOT=$(realpath $(dirname $_))
+SYSROOT=$(realpath $(dirname $0))
 source "${SYSROOT}/setup.sh" > /dev/null
 exec "$@"

--- a/sysroot/setup.sh
+++ b/sysroot/setup.sh
@@ -1,7 +1,7 @@
 #!/system/bin/env sh
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-SYSROOT=$(realpath $(dirname $_))
+SYSROOT=$(realpath $(dirname $0))
 
 echo "setting up sysroot installed at $SYSROOT"
 

--- a/sysroot/wrapper.sh.template
+++ b/sysroot/wrapper.sh.template
@@ -1,5 +1,5 @@
 #!/system/bin/env sh
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-SYSROOT=$(realpath $(dirname $_))
+SYSROOT=$(realpath $(dirname $0))
 exec "${SYSROOT}/run.sh" "<BIN>" "$@"


### PR DESCRIPTION
The reliance on `$_` seems wrong, as it leads to wrong sysroot inference
when one of the wrapper scripts is invoked in the context of another
program. E.g.,
```
$ timeout 10s bpftrace -e 'uprobe:/system/lib64/libc.so:malloc { @ = hist(arg0); }'
/vendor/bin/bpftrace[5]: /system/bin/run.sh: inaccessible or not found
```

As can be seen, the sysroot is inferred to be `/system/` in this case (the directory
in which `timeout` resides), which is not correct (everything bpf is located below
`/vendor`).

With this change we use `$0` instead of `$_` to fix this problem.