### PR TITLE
Allow building bpftools for armv7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # option.
 THREADS = 4
 
-# arch: arm64 or x86_64
+# arch: arm64, armv7, or x86_64
 NDK_ARCH = arm64
 
 # Release or Debug

--- a/projects/libbpf/build.mk
+++ b/projects/libbpf/build.mk
@@ -6,6 +6,7 @@ $(eval $(call project-define,libbpf))
 LIBBPF_EXTRA_CFLAGS += "-D__user="
 LIBBPF_EXTRA_CFLAGS += "-D__force="
 LIBBPF_EXTRA_CFLAGS += "-D__poll_t=unsigned"
+LIBBPF_EXTRA_CFLAGS += "-Wno-tautological-constant-out-of-range-compare"
 
 $(LIBBPF_ANDROID): \
     export PKG_CONFIG_LIBDIR=$(abspath $(ANDROID_OUT_DIR)/lib/pkgconfig)

--- a/projects/llvm/build.mk
+++ b/projects/llvm/build.mk
@@ -7,6 +7,8 @@ ifeq ($(NDK_ARCH), arm64)
 LLVM_HOST_TRIPLE = aarch64-none-linux-gnu
 else ifeq ($(NDK_ARCH), x86_64)
 LLVM_HOST_TRIPLE = x86_64-none-linux-gnu
+else ifeq ($(NDK_ARCH), armv7)
+LLVM_HOST_TRIPLE = armv7a-none-linux-gnueabi
 else
 $(error unknown abi $(NDK_ARCH))
 endif

--- a/sysroot/bpftools.mk
+++ b/sysroot/bpftools.mk
@@ -4,6 +4,8 @@ ifeq ($(NDK_ARCH), arm64)
 TARGET_ARCH_ENV_VAR = arm64
 else ifeq ($(NDK_ARCH), x86_64)
 TARGET_ARCH_ENV_VAR = x86
+else ifeq ($(NDK_ARCH), armv7)
+TARGET_ARCH_ENV_VAR = arm
 else
 $(error unknown abi $(NDK_ARCH))
 endif

--- a/toolchain/autotools.mk
+++ b/toolchain/autotools.mk
@@ -4,6 +4,8 @@ ifeq ($(NDK_ARCH), arm64)
 ANDROID_TRIPLE = aarch64-linux-android
 else ifeq ($(NDK_ARCH), x86_64)
 ANDROID_TRIPLE = x86_64-linux-android
+else ifeq ($(NDK_ARCH), armv7)
+ANDROID_TRIPLE = armv7a-linux-androideabi
 else
 $(error unknown abi $(NDK_ARCH))
 endif

--- a/toolchain/cmake.mk
+++ b/toolchain/cmake.mk
@@ -6,6 +6,8 @@ ifeq ($(NDK_ARCH), arm64)
 CMAKE_ABI = arm64-v8a
 else ifeq ($(NDK_ARCH), x86_64)
 CMAKE_ABI = x86_64
+else ifeq ($(NDK_ARCH), armv7)
+CMAKE_ABI = armeabi-v7a
 else
 $(error unknown abi $(NDK_ARCH))
 endif

--- a/toolchain/toolchain.mk
+++ b/toolchain/toolchain.mk
@@ -12,6 +12,8 @@ ifeq ($(NDK_ARCH), arm64)
 LIBCPP_ABI = arm64-v8a
 else ifeq ($(NDK_ARCH), x86_64)
 LIBCPP_ABI = x86_64
+else ifeq ($(NDK_ARCH), armv7)
+LIBCPP_ABI = armeabi-v7a
 else
 $(error unknown abi $(NDK_ARCH))
 endif


### PR DESCRIPTION
Adds armv7 as a supported build target for bpftrace and its dependencies:
```
$ make NDK_ARCH=armv7 bpftools
```

Note that upstream bpftrace doesn't compile for armv7 yet, so `BPFTRACE_COMMIT` isn't updated here; armv7 support is being added in iovisor/bpftrace#2360 and iovisor/bpftrace#2361.