### PR TITLE
limit number of llvm targets built

### DIFF
--- a/projects/llvm/build.mk
+++ b/projects/llvm/build.mk
@@ -4,10 +4,13 @@ LLVM_HOST_DEPS = cmake python
 $(eval $(call project-define,llvm))
 
 ifeq ($(NDK_ARCH), arm64)
+LLVM_DEFAULT_TARGET = AArch64
 LLVM_HOST_TRIPLE = aarch64-none-linux-gnu
 else ifeq ($(NDK_ARCH), x86_64)
+LLVM_DEFAULT_TARGET = X86
 LLVM_HOST_TRIPLE = x86_64-none-linux-gnu
 else ifeq ($(NDK_ARCH), armv7)
+LLVM_DEFAULT_TARGET = ARM
 LLVM_HOST_TRIPLE = armv7a-none-linux-gnueabi
 else
 $(error unknown abi $(NDK_ARCH))
@@ -22,6 +25,8 @@ endif
 
 ifeq ($(LLVM_BPF_ONLY),true)
 LLVM_EXTRA_CMAKE_FLAGS += -DLLVM_TARGETS_TO_BUILD=BPF
+else
+LLVM_EXTRA_CMAKE_FLAGS += -DLLVM_TARGETS_TO_BUILD="$(LLVM_DEFAULT_TARGET);BPF"
 endif
 
 $(LLVM_ANDROID):


### PR DESCRIPTION
@tnovak noticed that we're building llvm with support for unnecessary targets: we only need BPF and the host one (to enable some optional features of BCC).

This commit excludes unnecessary targets and makes the build faster (CI builds for this commit completed 30min sooner than for the base commit) and the final archives smaller (bpftools-arm64.tar.gz shrinks by 21MB).