### PR TITLE
strip bpftrace binary

### DIFF
--- a/projects/bpftrace/strip-thunk
+++ b/projects/bpftrace/strip-thunk
@@ -1,0 +1,4 @@
+#! /bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+<STRIP_PATH> --keep-symbol BEGIN_trigger --keep-symbol END_trigger "$@"

--- a/toolchain/toolchain.mk
+++ b/toolchain/toolchain.mk
@@ -4,6 +4,7 @@ NDK_API = 28
 NDK_PATH = /opt/ndk/android-ndk-r23b
 ANDROID_TOOLCHAIN_PATH = \
     $(abspath $(NDK_PATH)/toolchains/llvm/prebuilt/linux-x86_64/bin)
+ANDROID_TOOLCHAIN_STRIP_PATH = $(ANDROID_TOOLCHAIN_PATH)/llvm-strip
 
 include toolchain/autotools.mk
 include toolchain/cmake.mk


### PR DESCRIPTION
CMake invokes strip without giving us much option to preserve BEGIN_trigger or END_trigger symbols. We work around this problem by providing custom strip thunk that calls the real strip and specifies appropriate --keep-symbol options.