### PR TITLE
Update bpftrace to v0.18.1

### DIFF
--- a/projects/bpftrace/README
+++ b/projects/bpftrace/README
@@ -5,9 +5,6 @@ github: https://github.com/iovisor/bpftrace
 license: Apache 2.0
 license url: https://github.com/iovisor/bpftrace/blob/master/LICENSE
 
-Default version: 5d181c82acba400ec64e8d95c57cdb509f7cc57a
-- Main as of 10/14/2022. Includes support for armv7 and static linking.
-
 Building:
 - we need to tell cmake to use flex version that matches the lib and
   headers we have for Android. We set FLEX_EXECUTABLE to point to

--- a/projects/bpftrace/build.mk
+++ b/projects/bpftrace/build.mk
@@ -43,7 +43,7 @@ $(STRIP_THUNK): projects/bpftrace/strip-thunk | $(HOST_OUT_DIR)
 	@sed -e "s+<STRIP_PATH>+$(ANDROID_TOOLCHAIN_STRIP_PATH)+g" $< > $@
 	chmod +x $@
 
-BPFTRACE_COMMIT = 58bd61287de61ff14136cf0a7e1946db87121f5f
+BPFTRACE_COMMIT = v0.18.1
 BPFTRACE_REPO = https://github.com/iovisor/bpftrace.git/
 projects/bpftrace/sources:
 	git clone $(BPFTRACE_REPO) $@


### PR DESCRIPTION
Current `BPFTRACE_COMMIT` is from 2022-12. Switch to the latest release.

Among other changes, this includes [bpftrace#2527](https://github.com/iovisor/bpftrace/pull/2527) which fixes BTF detection on older kernels.