### PR TITLE
Scaffolding jdwp  for new JDWP debugger project

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,17 @@
+[repositories]
+root = .
+prelude = prelude
+toolchains = toolchains
+none = none
+
+[repository_aliases]
+config = prelude
+fbcode = none
+fbsource = none
+buck = none
+
+[parser]
+target_platform_detector_spec = target:root//...->prelude//platforms:default
+
+[project]
+ignore = .git

--- a/.buckconfig
+++ b/.buckconfig
@@ -15,7 +15,3 @@ target_platform_detector_spec = target:root//...->prelude//platforms:default
 
 [project]
 ignore = .git
-
-[python]
-interpreter_path = /out/host/bin/python3
-typed_python_config = /out/host/bin/pyre

--- a/.buckconfig
+++ b/.buckconfig
@@ -15,3 +15,7 @@ target_platform_detector_spec = target:root//...->prelude//platforms:default
 
 [project]
 ignore = .git
+
+[python]
+interpreter_path = /out/host/bin/python3
+typed_python_config = /out/host/bin/pyre

--- a/.buckconfig
+++ b/.buckconfig
@@ -19,4 +19,3 @@ ignore = .git
 [python]
 interpreter_path = /out/host/bin/python3
 typed_python_config = /out/host/bin/pyre
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "prelude"]
+	path = prelude
+	url = https://github.com/facebook/buck2-prelude.git

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,7 @@
+# A list of available rules and their signatures can be found here: https://buck2.build/docs/api/rules/
+
+genrule(
+    name = "hello_world",
+    out = "out.txt",
+    cmd = "echo BUILT BY BUCK2> $OUT",
+)

--- a/BUCK
+++ b/BUCK
@@ -1,7 +1,0 @@
-# A list of available rules and their signatures can be found here: https://buck2.build/docs/api/rules/
-
-genrule(
-    name = "hello_world",
-    out = "out.txt",
-    cmd = "echo BUILT BY BUCK2> $OUT",
-)

--- a/projects/buck2/build.mk
+++ b/projects/buck2/build.mk
@@ -19,7 +19,7 @@ RELEASE_URL := https://github.com/facebook/$(PROJECT_NAME)/releases/download/$(P
 # Check if wget is available and install it if missing
 WGET := $(shell command -v wget 2> /dev/null)
 ifeq ($(WGET),)
-    WGET := $(shell sudo apt-get -qy install wget && command -v wget)
+    WGET := $(shell apt-get -qy install wget && command -v wget)
     ifeq ($(WGET),)
         $(error "Failed to install wget. Please install it manually and try again.")
     endif
@@ -28,7 +28,7 @@ endif
 # Check if zstd is available and install it if missing
 ZSTD := $(shell command -v zstd 2> /dev/null)
 ifeq ($(ZSTD),)
-    ZSTD := $(shell sudo apt-get -qy install zstd && command -v zstd)
+    ZSTD := $(shell apt-get -qy install zstd && command -v zstd)
     ifeq ($(ZSTD),)
         $(error "Failed to install zstd. Please install it manually and try again.")
     endif

--- a/projects/buck2/build.mk
+++ b/projects/buck2/build.mk
@@ -1,0 +1,50 @@
+# Makefile for downloading and installing the Buck2 binary
+$(eval $(call project-define,buck2))
+
+# Project-specific variables
+PROJECT_NAME := buck2
+PROJECT_VERSION := 2023-09-01
+
+# Installation directories
+INSTALL_DIR := out/host/bin
+
+# Binary name and paths
+BINARY_NAME := buck2
+BINARY_PATH := $(INSTALL_DIR)/$(BINARY_NAME)
+COMPRESSED_BINARY := $(BINARY_PATH).zst
+
+# URL for the release asset
+RELEASE_URL := https://github.com/facebook/$(PROJECT_NAME)/releases/download/$(PROJECT_VERSION)/$(BINARY_NAME)-x86_64-unknown-linux-gnu.zst
+
+# Check if wget is available and install it if missing
+WGET := $(shell command -v wget 2> /dev/null)
+ifeq ($(WGET),)
+    WGET := $(shell sudo apt-get -qy install wget && command -v wget)
+    ifeq ($(WGET),)
+        $(error "Failed to install wget. Please install it manually and try again.")
+    endif
+endif
+
+# Check if zstd is available and install it if missing
+ZSTD := $(shell command -v zstd 2> /dev/null)
+ifeq ($(ZSTD),)
+    ZSTD := $(shell sudo apt-get -qy install zstd && command -v zstd)
+    ifeq ($(ZSTD),)
+        $(error "Failed to install zstd. Please install it manually and try again.")
+    endif
+endif
+
+# Target to download and install the binary
+$(BINARY_PATH): | $(INSTALL_DIR)
+	$(WGET) -q -O $(COMPRESSED_BINARY) $(RELEASE_URL)
+	$(ZSTD) -d -o $(BINARY_PATH) $(COMPRESSED_BINARY)
+	chmod +x $(BINARY_PATH)
+	rm $(COMPRESSED_BINARY)
+
+# Target to create the installation directory if it doesn't exist
+$(INSTALL_DIR):
+	mkdir -p $@
+
+
+# Default target to fetch and install the binary
+projects/buck2/sources: $(BINARY_PATH)

--- a/projects/buck2/build.mk
+++ b/projects/buck2/build.mk
@@ -1,12 +1,10 @@
-# Makefile for downloading and installing the Buck2 binary
-$(eval $(call project-define,buck2))
-
 # Project-specific variables
 PROJECT_NAME := buck2
 PROJECT_VERSION := 2023-09-01
 
 # Installation directories
 INSTALL_DIR := out/host/bin
+BUCK2_DONE := build/host/buck2.done
 
 # Binary name and paths
 BINARY_NAME := buck2
@@ -45,6 +43,8 @@ $(BINARY_PATH): | $(INSTALL_DIR)
 $(INSTALL_DIR):
 	mkdir -p $@
 
+$(BUCK2_DONE): $(BINARY_PATH)
+	touch $@
 
 # Default target to fetch and install the binary
-projects/buck2/sources: $(BINARY_PATH)
+buck2-host: $(BUCK2_DONE)

--- a/projects/jdwp/.pyre_configuration
+++ b/projects/jdwp/.pyre_configuration
@@ -1,0 +1,7 @@
+{
+  "site_package_search_strategy": "pep561",
+  "source_directories": [
+    "main",
+    "tests"
+  ]
+}

--- a/projects/jdwp/.pyre_configuration
+++ b/projects/jdwp/.pyre_configuration
@@ -1,7 +1,5 @@
 {
-  "site_package_search_strategy": "pep561",
-  "source_directories": [
-    "main",
-    "tests"
+  "targets": [
+    "//projects/jdwp/..."
   ]
 }

--- a/projects/jdwp/BUCK
+++ b/projects/jdwp/BUCK
@@ -1,11 +1,12 @@
-jdwp_binary(
+python_binary(
   name = "main",
-  srcs = [],
+  main = "main.py",
   deps = [],
 )
 
-jdwp_library(
-  name = "lib",
-  srcs = [],
-  visibility = ["PUBLIC"],
+
+python_library(
+    name = "lib",
+    srcs = [],
+    visibility = ["PUBLIC"],
 )

--- a/projects/jdwp/BUCK
+++ b/projects/jdwp/BUCK
@@ -1,0 +1,11 @@
+jdwp_binary(
+  name = "main",
+  srcs = [],
+  deps = [],
+)
+
+jdwp_library(
+  name = "lib",
+  srcs = [],
+  visibility = ["PUBLIC"],
+)

--- a/projects/jdwp/BUCK
+++ b/projects/jdwp/BUCK
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 python_binary(
   name = "main",
   main = "main.py",

--- a/projects/jdwp/main.py
+++ b/projects/jdwp/main.py
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 def main():
   return None
 

--- a/projects/jdwp/main.py
+++ b/projects/jdwp/main.py
@@ -1,0 +1,5 @@
+def main():
+  return None
+
+if __name__ == "__main__":
+  main()

--- a/projects/jdwp/tests/BUCK
+++ b/projects/jdwp/tests/BUCK
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 python_test(
   name = "tests",
   srcs = glob(["*.py"]),

--- a/projects/jdwp/tests/BUCK
+++ b/projects/jdwp/tests/BUCK
@@ -1,5 +1,4 @@
-jdwp_test(
+python_test(
   name = "tests",
-  srcs = [],
-  deps = [],
+  srcs = glob(["*.py"]),
 )

--- a/projects/jdwp/tests/BUCK
+++ b/projects/jdwp/tests/BUCK
@@ -1,0 +1,5 @@
+jdwp_test(
+  name = "tests",
+  srcs = [],
+  deps = [],
+)

--- a/projects/pyre/build.mk
+++ b/projects/pyre/build.mk
@@ -1,0 +1,6 @@
+PYRE_HOST_DEPS = python
+$(eval $(call project-define,pyre))
+
+
+projects/pyre/sources:
+	$(HOST_OUT_DIR)/bin/python3 -m pip install pyre-check

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,0 +1,6 @@
+load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
+
+system_genrule_toolchain(
+    name = "genrule",
+    visibility = ["PUBLIC"],
+)

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,3 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
 

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,6 +1,17 @@
-load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
+load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
+load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
 
-system_genrule_toolchain(
-    name = "genrule",
+system_cxx_toolchain(
+    name = "cxx",
+    visibility = ["PUBLIC"],
+)
+
+system_python_toolchain(
+    name = "python",
+    visibility = ["PUBLIC"],
+)
+
+system_python_bootstrap_toolchain(
+    name = "python_bootstrap",
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
This pull request addresses the issue #53, however I'm currently facing an issue with running the placeholder targets e.g `buck2 run //projects/jdwp:main`. An error is thrown as 
```
From `load` at implicit location

Caused by:
    0: From `load` at prelude/prelude.bzl:8:6-29
    1: From `load` at prelude/native.bzl:15:6-45
    2: From `load` at prelude/apple/apple_macro_layer.bzl:14:5-36
    3: From `load` at prelude/apple/apple_rules_impl_utility.bzl:9:6-46
    4: From `load` at prelude/apple/apple_bundle_types.bzl:8:6-18
    5: From `load` at prelude/apple/debug.bzl:9:5-35
    6: Error evaluating module: `prelude//artifact_tset.bzl`
    7: Traceback (most recent call last):
         * prelude/artifact_tset.bzl:29, in <module>
             _tset = field([_ArtifactTSet, None], None),
       error: Found `_ArtifactTSet` instead of a valid type annotation. Perhaps you meant `"_ArtifactTSet"`?
         --> prelude/artifact_tset.bzl:29:13
          |
       29 |     _tset = field([_ArtifactTSet, None], None),
          |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          |
       
Build ID: 0a784514-076a-44d5-80c9-42d81616c2e8
Jobs completed: 3. Time elapsed: 0.2s.
BUILD FAILED

```