### PR TITLE
make targets automating project/jdwp tasks

### DIFF
--- a/projects/black/README
+++ b/projects/black/README
@@ -1,0 +1,5 @@
+Black
+Black is the uncompromising Python code formatter.
+
+github: https://github.com/psf/black
+license url: https://github.com/psf/black#license

--- a/projects/black/build.mk
+++ b/projects/black/build.mk
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+BLACK_DONE := build/host/black.done
+
+black-host: $(BLACK_DONE)
+
+$(BLACK_DONE): python-host
+	$(HOST_OUT_DIR)/bin/python3 -m pip install black
+	mkdir -p build/host
+	touch $@

--- a/projects/black/build.mk
+++ b/projects/black/build.mk
@@ -1,10 +1,3 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-BLACK_DONE := build/host/black.done
-
-black-host: $(BLACK_DONE)
-
-$(BLACK_DONE): python-host
-	$(HOST_OUT_DIR)/bin/python3 -m pip install black
-	mkdir -p build/host
-	touch $@
+$(eval $(call pip-project,black))

--- a/projects/jdwp/build.mk
+++ b/projects/jdwp/build.mk
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+jdwp-host-prepare: \
+  black-host \
+  buck2-host \
+  python-host \
+  pyre-host
+
+jdwp-check: jdwp-host-prepare
+	buck2 run //projects/jdwp:main
+	buck2 test //projects/jdwp/...
+	pyre check
+	black projects/jdwp --check
+
+jdwp-format: black-host
+	black projects/jdwp

--- a/projects/project.mk
+++ b/projects/project.mk
@@ -198,3 +198,17 @@ define project-define =
   .PHONY: remove-$(1)-sources
   remove-$(1)-sources: ; rm -rf projects/$(1)/sources
 endef
+
+# Macro defining rules installing a python library/tool via pip
+define pip-project =
+  $(call project-to-var,$(1))_HOST := \
+      $(call project-host-target,$(1))
+
+  $(1)-host: $(call project-host-target,$(1))
+
+  $(call project-host-target,$(1)): \
+      $(call project-host-target,python) \
+      | $(HOST_BUILD_DIR)
+	python3 -m pip install $(if $(2),$(2),$(1))
+	touch $$@
+endef

--- a/projects/pyre/build.mk
+++ b/projects/pyre/build.mk
@@ -1,10 +1,3 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-PYRE_CHECK_DONE := build/host/pyre-check.done
-
-pyre-host: $(PYRE_CHECK_DONE)
-
-$(PYRE_CHECK_DONE): python-host
-	$(HOST_OUT_DIR)/bin/python3 -m pip install pyre-check
-	mkdir -p build/host
-	touch $@
+$(eval $(call pip-project,pyre,pyre-check))


### PR DESCRIPTION
- `make jdwp-host-prepare` installs all tools needed for development of `projects/jdwp`
- `make jdwp-format` formats python sources
- `make jdwp-check` ensures `projects/jdwp` builds, type checks, is well formatted and associated tests pass