### PR TITLE
Update bpftools to latest versions

### DIFF
--- a/projects/bcc/build.mk
+++ b/projects/bcc/build.mk
@@ -26,10 +26,10 @@ $(BCC_ANDROID_BUILD_DIR): $(HOST_OUT_DIR)/bin/flex
 		-DBPS_LINK_RT=OFF \
 		-DENABLE_TESTS=OFF \
 		-DCMAKE_USE_LIBBPF_PACKAGE=ON \
-		-DPYTHON_CMD=$(abspath $(HOST_OUT_DIR)/bin/python3.10-no--install-layout) \
-		-DREVISION=0.27.0
+		-DPYTHON_CMD=$(abspath $(HOST_OUT_DIR)/bin/python3.10-no--install-layout)
 
-BCC_TAG = v0.27.0
+BCC_COMMIT = b8b943a19132936751e1a5d67360a34050f4c2e0
 BCC_REPO = https://github.com/iovisor/bcc
 projects/bcc/sources:
-	git clone $(BCC_REPO) $@ --depth=1 -b $(BCC_TAG)
+	git clone $(BCC_REPO) $@
+	cd $@ && git checkout $(BCC_COMMIT)

--- a/projects/bpftrace/build.mk
+++ b/projects/bpftrace/build.mk
@@ -43,7 +43,7 @@ $(STRIP_THUNK): projects/bpftrace/strip-thunk | $(HOST_OUT_DIR)
 	@sed -e "s+<STRIP_PATH>+$(ANDROID_TOOLCHAIN_STRIP_PATH)+g" $< > $@
 	chmod +x $@
 
-BPFTRACE_COMMIT = v0.18.1
+BPFTRACE_COMMIT = v0.19.1
 BPFTRACE_REPO = https://github.com/iovisor/bpftrace.git/
 projects/bpftrace/sources:
 	git clone $(BPFTRACE_REPO) $@

--- a/projects/elfutils/build.mk
+++ b/projects/elfutils/build.mk
@@ -20,7 +20,8 @@ $(ANDROID_BUILD_DIR)/elfutils: $(ANDROID_OUT_DIR)/lib/pkgconfig/zlib.pc
 	cd $@ && EXTRA_CFLAGS="$(ELFUTILS_EXTRA_CFLAGS)" $(ELFUTILS_SRCS)/configure \
 		$(ANDROID_EXTRA_CONFIGURE_FLAGS) \
 		--disable-debuginfod \
-		--disable-libdebuginfod
+		--disable-libdebuginfod \
+		--enable-install-elfh
 
 ELFUTILS_VERSION = 0.186
 ELFUTILS_URL = http://sourceware.org/pub/elfutils/$(ELFUTILS_VERSION)/elfutils-$(ELFUTILS_VERSION).tar.bz2

--- a/projects/libbpf/build.mk
+++ b/projects/libbpf/build.mk
@@ -25,7 +25,7 @@ $(LIBBPF_ANDROID): $(ANDROID_OUT_DIR)/lib/pkgconfig/zlib.pc
 $(LIBBPF_ANDROID_BUILD_DIR):
 	mkdir -p $@
 
-LIBBPF_TAG = v1.0.0
+LIBBPF_TAG = v1.2.2
 LIBBPF_REPO = https://github.com/libbpf/libbpf
 projects/libbpf/sources:
 	git clone $(LIBBPF_REPO) $@ -b $(LIBBPF_TAG)


### PR DESCRIPTION
Pulls the following versions of BPF packages:

- bpftrace: 0.19.1
- libbpf: 1.2.2
- bcc: 0.28-gb8b943a1 (commit b8b943a1)

This version of bpftrace speeds up symbol resolution [1] and fixes ustack symbolication on 32-bit systems [2].

[1] https://github.com/iovisor/bpftrace/pull/2386
[2] https://github.com/iovisor/bcc/pull/4775