### PR TITLE
upgrade github action from v3 to v4

### DIFF
--- a/.github/workflows/bpftools.yml
+++ b/.github/workflows/bpftools.yml
@@ -12,7 +12,7 @@ jobs:
           - ARCH: arm64
           - ARCH: x86_64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo ./scripts/jammy-install-deps.sh
       - name: Setup NDK
@@ -34,7 +34,7 @@ jobs:
           - ARCH: arm64
           - ARCH: x86_64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo ./scripts/jammy-install-deps.sh
       - name: Setup NDK
@@ -56,7 +56,7 @@ jobs:
           - ARCH: x86_64
           - ARCH: armv7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo ./scripts/jammy-install-deps.sh
       - name: Setup NDK

--- a/.github/workflows/bpftools.yml
+++ b/.github/workflows/bpftools.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build
         env: ${{matrix.env}}
         run: make bpftools NDK_PATH=`pwd`/android-ndk-r27b NDK_ARCH=${{ matrix.env['ARCH'] }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bpftools-android-${{ matrix.env['ARCH'] }}.tar.gz
           path: bpftools-${{ matrix.env['ARCH'] }}.tar.gz
@@ -41,7 +41,7 @@ jobs:
         run: ./scripts/download-ndk.sh
       - name: Build
         run: make bpftools-min NDK_PATH=`pwd`/android-ndk-r27b NDK_ARCH=${{ matrix.env['ARCH'] }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bpftools-min-android-${{ matrix.env['ARCH'] }}.tar.gz
           path: bpftools-min-${{ matrix.env['ARCH'] }}.tar.gz
@@ -63,7 +63,7 @@ jobs:
         run: ./scripts/download-ndk.sh
       - name: Build
         run: make bpftrace NDK_PATH=`pwd`/android-ndk-r27b NDK_ARCH=${{ matrix.env['ARCH'] }} STATIC_LINKING=true LLVM_BPF_ONLY=true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bpftrace-android-${{ matrix.env['ARCH'] }}
           path: out/android/${{ matrix.env['ARCH'] }}/bin/bpftrace

--- a/.github/workflows/jdwp.yml
+++ b/.github/workflows/jdwp.yml
@@ -6,7 +6,7 @@ jobs:
   build_jdwp_project:
     name: Build and Test JDWP Project
     runs-on: ubuntu-22.04
-    
+
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v3
@@ -25,4 +25,4 @@ jobs:
     - name: Run Pyre Type Checking
       run: |
         eval `make setup-env`
-        cd projects/jdwp && pyre check
+        cd projects/jdwp && pyre --version=client check

--- a/projects/gnulib/build.mk
+++ b/projects/gnulib/build.mk
@@ -7,7 +7,7 @@ $(GNULIB_ANDROID):
 	false
 
 GNULIB_COMMIT_HASH = 044bf893acee0a55b22b4be0ede0e3ce010c480a
-GNULIB_REPO = https://git.savannah.gnu.org/git/gnulib.git
+GNULIB_REPO = https://github.com/simpleton/gnulib-mirror
 projects/gnulib/sources:
 	git clone $(GNULIB_REPO) $@
 	cd $@ && git checkout $(GNULIB_COMMIT_HASH)


### PR DESCRIPTION
address the below issue: https://github.com/facebookexperimental/ExtendedAndroidTools/actions/runs/15052744399/job/42311263128?pr=109

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/