### PR TITLE
ci: use the github url to fetch the license

### DIFF
--- a/projects/licenses.mk
+++ b/projects/licenses.mk
@@ -2,6 +2,7 @@
 
 # Definitions of licensing macros
 
-LGPL_URL := https://www.gnu.org/licenses/lgpl-3.0.txt
+# https://www.gnu.org/licenses/lgpl-3.0.txt
+LGPL_URL := https://raw.githubusercontent.com/facebookexperimental/ExtendedAndroidTools/refs/heads/main/licenses/lgpl-3.0.txt
 
 fetch-license = curl -L $($(2)_URL) -o $(ANDROID_OUT_DIR)/licenses/$(1)


### PR DESCRIPTION
There're couple action job failed due to connection timed out on gnu.org website. 
```
curl -L https://www.gnu.org/licenses/lgpl-3.0.txt -o out/android/arm64/licenses/argp

curl: (28) Failed to connect to www.gnu.org port 443 after 135751 ms: Connection timed out
make: *** [projects/argp/build.mk:10: build/android/arm64/argp.done] Error 28
```