### PR TITLE
Add Z flag in run-docker-build-env.sh for podman compatibility

### DIFF
--- a/scripts/run-docker-build-env.sh
+++ b/scripts/run-docker-build-env.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-docker run -it --rm -v "$(pwd):/ExtendedAndroidTools" extended-android-tools
+docker run -it --rm -v "$(pwd):/ExtendedAndroidTools:Z" extended-android-tools


### PR DESCRIPTION
@alfonsoalongi
Description
[alfonsoalongi](https://github.com/alfonsoalongi)
opened [on May 21, 2025](https://github.com/facebookexperimental/ExtendedAndroidTools/issues/114#issue-3079157150)

Hello,
can you add the flag "Z" to mount the volume with correct permissions also in podman?
The file is run-docker-build-env.sh.

docker run -it --rm -v "$(pwd):/ExtendedAndroidTools:Z" extended-android-tools

Thank you in advance.