### PR TITLE
Build the Extended Android Tools image from scratch (fresh ubuntu:jammy + no cache)

### DIFF
--- a/scripts/build-docker-image.sh
+++ b/scripts/build-docker-image.sh
@@ -2,5 +2,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 pushd scripts
-docker build -t extended-android-tools -f ../docker/Dockerfile .
+docker build --pull --no-cache -t extended-android-tools -f ../docker/Dockerfile .
 popd


### PR DESCRIPTION
Hi team,

I tweaked **build-docker-image.sh** so the build now runs with both `--pull` *and* `--no-cache`:

```bash
docker build --pull --no-cache -t extended-android-tools -f ../docker/Dockerfile .
```

---

#### Why we need this

1. **Stay in sync with upstream code**
   The repo `facebookexperimental/ExtendedAndroidTools` moves quickly. If Docker reuses cached layers we can end up compiling an old snapshot and chasing “it-works-on-my-machine” bugs.

2. **Track the real `ubuntu:jammy` tag**
   `ubuntu:jammy` is a rolling alias for 22.04 LTS. New package versions, not just security patches, land under the same tag. `--pull` fetches the latest digest only when it has actually changed, so we don’t waste bandwidth but we do stay current.

3. **Reproducible, deterministic builds**
   A full rebuild makes sure anyone who runs the script—locally or in CI—gets an identical image that reflects the *current* state of both the base OS and the toolchain sources. This lines up with how our GitLab workflows already treat Docker images: build once, push, and pin the digest downstream.

#### How this helps day-to-day

* **Fewer “mystery” bugs** – we eliminate the mismatch between code, packages, and container.
* **Clean diff in CI** – GitLab runners always build on a known good base, so failing jobs are easier to reproduce locally.
* **No performance penalty in practice** – the script is invoked only the first time you need the toolchain or when you *intend* to refresh it, so the extra minutes for a cold build are harmless.

---

Thanks.
