### PR TITLE
bpftrace: Fix __data_loc reads

### DIFF
--- a/projects/bpftrace/build.mk
+++ b/projects/bpftrace/build.mk
@@ -49,4 +49,4 @@ projects/bpftrace/sources:
 	git clone $(BPFTRACE_REPO) $@ && \
 	cd $@ && \
 	git checkout $(BPFTRACE_COMMIT) && \
-	git cherry-pick 4b5cbe120f581846d5397fa4b2a0cbd34e15c77a --no-commit
+	git cherry-pick 4b5cbe120f581846d5397fa4b2a0cbd34e15c77a 665b754a5800d80d44a95699a6d5ec545a7b7065 --no-commit -X theirs


### PR DESCRIPTION
cherry-pick https://github.com/bpftrace/bpftrace/commit/665b754a5800d80d44a95699a6d5ec545a7b7065

A __data_loc field is an (offset, len) pair; its value is determined by
adding the offset (in bytes) to the address of the tracepoint struct.

Commit https://github.com/bpftrace/bpftrace/commit/06a8972510d998ce52a9cbfa444ff95ed7249760 ("codegen: use preserve_static_offset intrinsic")
replaced the add instruction with getelementptr, but used i32 as the
GEP type without adjusting the offset. This causes the value to be
incorrectly set to ctx + 4*offset.

For example, this currently prints an empty or incomplete filename:

  bpftrace -e 't:sched:sched_process_exec { print(str(args.filename)) }'

Fix it by changing the getelementptr type argument to i8.