### PR TITLE
Add option to not strip bpftrace in release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ STATIC_LINKING = false
 # requires support for the $NDK_ARCH target)
 LLVM_BPF_ONLY = false
 
+# Set to true to avoid stripping the final bpftrace binary even in the Release
+# build configuration.
+BPFTRACE_NO_STRIP = false
+
 BUILD_DIR = build
 ANDROID_BUILD_DIR = $(BUILD_DIR)/android/$(NDK_ARCH)
 HOST_BUILD_DIR = $(BUILD_DIR)/host

--- a/projects/bpftrace/build.mk
+++ b/projects/bpftrace/build.mk
@@ -16,10 +16,14 @@ BPFTRACE_EXTRA_CMAKE_FLAGS = -DSTATIC_LINKING=ON
 BPFTRACE_EXTRA_LDFLAGS += "$(abspath $(ANDROID_OUT_DIR))/lib/liblzma.a"
 endif
 
+ifeq ($(BUILD_TYPE),Debug)
+BPFTRACE_NO_STRIP := true
+endif
+
 STRIP_THUNK = $(HOST_OUT_DIR)/bpftrace-strip-thunk
 
 $(BPFTRACE_ANDROID): $(ANDROID_OUT_DIR)/lib/libc++_shared.so
-ifeq ($(BUILD_TYPE), Debug)
+ifeq ($(BPFTRACE_NO_STRIP),true)
 	cd $(BPFTRACE_ANDROID_BUILD_DIR) && $(MAKE) install -j $(THREADS)
 else
 	cd $(BPFTRACE_ANDROID_BUILD_DIR) && $(MAKE) install/strip -j $(THREADS)


### PR DESCRIPTION
Don't strip the binary if `BPFTRACE_NO_STRIP=true`.

This can be useful when adding bpftrace as a prebuilt to Android: the AOSP build system strips the binary to reduce its size (while keeping the symbol table in `.gnu_debugdata`), and the original can be used for debugging if needed.